### PR TITLE
Adding test for land & home CRUD operations with authorization and authentication

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -7,7 +7,6 @@ generateToken = async (authInfo) => {
 };
 
 const loginUser = async (req, res) => {
-    console.log('logingggggggggggggggggggggggggggggggggggggggg');
     const { email, password } = req.body;
 
     console.log(email);

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -7,6 +7,7 @@ generateToken = async (authInfo) => {
 };
 
 const loginUser = async (req, res) => {
+    console.log('logingggggggggggggggggggggggggggggggggggggggg');
     const { email, password } = req.body;
 
     console.log(email);

--- a/middlewares/verifyRole.js
+++ b/middlewares/verifyRole.js
@@ -1,8 +1,8 @@
 const verifyRole = (roles) => {
     return (req, res, next) => {
         console.log('Verifying Role');
-        if (!req.auth_role) return res.sendStatus(401);
-        if (!roles.includes(req.auth_role)) return res.sendStatus(401);
+        if (!req.auth_role) return res.sendStatus(403);
+        if (!roles.includes(req.auth_role)) return res.sendStatus(403);
         next();
     };
 };

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,10 +1,8 @@
 const express = require('express');
 const router = express.Router();
-const {loginUser,logoutUser} = require("../controllers/authController")
-
+const { loginUser, logoutUser } = require('../controllers/authController');
 
 router.post('/login', loginUser);
 router.post('/logout', logoutUser);
-
 
 module.exports = router;

--- a/routes/home.js
+++ b/routes/home.js
@@ -27,7 +27,6 @@ const { addPhotoName } = require('../services/homeService');
 const CONTAINER_NAME = process.env.CONTAINER_NAME;
 const AZURE_STORAGE_CONNECTION_STRING = process.env.AZURE_STORAGE_CONNECTION_STRING;
 
-
 const reqBodyToObject = (req) => ({
     title: req.body.title,
     city: req.body.city,
@@ -221,10 +220,7 @@ router.put(
             res.status(400).json(errors);
             return;
         }
-        if (!(await getHomeById(homeId))) {
-            res.status(400).json('Home not found!');
-            return;
-        }
+
         if (
             !(await isHomeBelongToOwner(homeId, req.auth_id)) &&
             req.auth_role !== ROLES_ENUMS.Admin

--- a/routes/land.js
+++ b/routes/land.js
@@ -144,7 +144,7 @@ router.put(
             !(await isLandBelongToOwner(landId, req.auth_id)) &&
             req.auth_role !== ROLES_ENUMS.Admin
         ) {
-            res.status(403).json('You do not have permission to delete this land!');
+            res.status(403).json('You do not have permission to Edit this land!');
             return;
         }
 

--- a/services/landService.js
+++ b/services/landService.js
@@ -10,8 +10,10 @@ async function createLand(land) {
 async function getLandById(landId) {
     const land = await Land.findById(landId);
     if (!land) return null;
+
     const ownerId = land.owner.toString();
     const owner = await User.findById(ownerId);
+    if (!owner) return null;
     const ownerNames = `${owner.first_name} ${owner.last_name}`;
     const landInfo = {
         owner_names: ownerNames,
@@ -46,6 +48,7 @@ async function getAllLands() {
 
 async function isLandBelongToOwner(landId, ownerid) {
     const land = await Land.findById(landId);
+    console.log(land, '===========', landId);
     if (!land) return false;
     return ownerid === land.owner.toString();
 }

--- a/test/home/homeDelete.test.js
+++ b/test/home/homeDelete.test.js
@@ -1,51 +1,162 @@
 const mockingoose = require('mockingoose');
 const Homes = require('../../models/Homes');
+const jwt = require('jsonwebtoken');
 const request = require('supertest');
+const User = require('../../models/User');
 const app = require('../../app');
 
 describe('Positive DELETE /home', () => {
-    it('should delete home by id', async () => {
-        mockingoose(Homes).toReturn(
-            {
-                _id: '652beab54298559b57ff172f',
-                title: 'Nice house',
-                city: 'Dobrich',
-                neighborhood: 'Drujba',
-                address: 'Blok 42 A 2 8',
-                price: '10000',
-                size: '150',
-                year: '1960',
-                description: 'Really nice house, have 2 rooms',
-                longitude: '30',
-                latitude: '50',
-                owner_id: '632beab54298559b57ff172f',
-                homeViews: '200',
-            },
-            'findOne'
-        );
-        mockingoose(Homes).toReturn(
-            {
-                _id: '652beab54298559b57ff172f',
-                title: 'Nice house',
-                city: 'Dobrich',
-                neighborhood: 'Drujba',
-                address: 'Blok 42 A 2 8',
-                price: '10000',
-                size: '150',
-                year: '1960',
-                description: 'Really nice house, have 2 rooms',
-                longitude: '30',
-                latitude: '50',
-                owner_id: '632beab54298559b57ff172f',
-                homeViews: '200',
-            },
-            'findByIdAndDelete'
-        );
-        const res = await request(app)
-            .delete(`/home`)
-            .send({ home_id: '652beab54298559b57ff172f' });
+    describe('given the request header berer not exist', () => {
+        it('should return a 401', async () => {
+            const { statusCode } = await request(app).delete(`/home`);
+            expect(statusCode).toBe(401);
+        });
+    });
 
-        expect(res.statusCode).toEqual(200);
-        expect(res.body).toEqual('Home has been deleted');
+    describe('given the token is not valid', () => {
+        it('should return a 403', async () => {
+            const { statusCode } = await request(app)
+                .delete(`/home`)
+                .set('Authorization', `Bearer Wrong Token`);
+            expect(statusCode).toBe(403);
+        });
+    });
+
+    describe('given the user dosent have permission', () => {
+        it('should return a 403', async () => {
+            const token = jwt.sign(
+                { auth_id: '63c93c7ea886abcac9deefe8', auth_role: 'user' },
+                process.env.JWT_SECRET,
+                {
+                    expiresIn: '1d',
+                }
+            );
+            const { statusCode } = await request(app)
+                .delete(`/home`)
+                .set('Authorization', `Bearer ${token}`);
+            expect(statusCode).toBe(403);
+        });
+    });
+
+    describe('given the home not exist', () => {
+        it('should return a 400', async () => {
+            const token = jwt.sign(
+                { auth_id: '63c93c7ea886abcac9deefe8', auth_role: 'seller' },
+                process.env.JWT_SECRET,
+                {
+                    expiresIn: '1d',
+                }
+            );
+
+            const { statusCode } = await request(app)
+                .delete(`/home`)
+                .set('Authorization', `Bearer ${token}`)
+                .send({ home_id: '652beab54298449b57ff172f' /*wrong id*/ });
+
+            expect(statusCode).toBe(400);
+        });
+    });
+
+    describe('given the home dosent belong to the user', () => {
+        it('should return a 403', async () => {
+            const token = jwt.sign(
+                { auth_id: '63c93c7ea886abcac7deefe8' /*wrong id*/, auth_role: 'seller' },
+                process.env.JWT_SECRET,
+                {
+                    expiresIn: '1d',
+                }
+            );
+            mockingoose(User).toReturn(
+                {
+                    _id: '63c93c7ea886abcac9deefe8',
+                    first_name: 'test',
+                    last_name: 'test',
+                    email: 'test@gmail.com',
+                    password: '$2b$10$PtuFEjpqdr50hldhr4K36ODgzYKtz6QBO7KxB9OgCgcEP4ihxWuUa',
+                    role: 'seller',
+                    phone_number: '+112557441454',
+                },
+                'findOne'
+            );
+            mockingoose(Homes).toReturn(
+                {
+                    _id: '652beab54298559b57ff172f',
+                    title: 'Nice house',
+                    city: 'Dobrich',
+                    neighborhood: 'Drujba',
+                    address: 'Blok 42 A 2 8',
+                    price: '10000',
+                    size: '150',
+                    year: '1960',
+                    description: 'Really nice house, have 2 rooms',
+                    longitude: '30',
+                    latitude: '50',
+                    owner_id: '63c93c7ea886abcac9deefe8',
+                    homeViews: '200',
+                },
+                'findOne'
+            );
+            const { statusCode } = await request(app)
+                .delete(`/home`)
+                .set('Authorization', `Bearer ${token}`)
+                .send({ home_id: '652beab54298559b57ff172f' });
+            expect(statusCode).toBe(403);
+        });
+    });
+
+    describe('given the user is logged in', () => {
+        it('should delete home by id', async () => {
+            const token = jwt.sign(
+                { auth_id: '632beab54298559b57ff172f', auth_role: 'seller' },
+                process.env.JWT_SECRET,
+                {
+                    expiresIn: '1d',
+                }
+            );
+
+            mockingoose(Homes).toReturn(
+                {
+                    _id: '652beab54298559b57ff172f',
+                    title: 'Nice house',
+                    city: 'Dobrich',
+                    neighborhood: 'Drujba',
+                    address: 'Blok 42 A 2 8',
+                    price: '10000',
+                    size: '150',
+                    year: '1960',
+                    description: 'Really nice house, have 2 rooms',
+                    longitude: '30',
+                    latitude: '50',
+                    owner_id: '632beab54298559b57ff172f',
+                    homeViews: '200',
+                },
+                'findOne'
+            );
+            mockingoose(Homes).toReturn(
+                {
+                    _id: '652beab54298559b57ff172f',
+                    title: 'Nice house',
+                    city: 'Dobrich',
+                    neighborhood: 'Drujba',
+                    address: 'Blok 42 A 2 8',
+                    price: '10000',
+                    size: '150',
+                    year: '1960',
+                    description: 'Really nice house, have 2 rooms',
+                    longitude: '30',
+                    latitude: '50',
+                    owner_id: '632beab54298559b57ff172f',
+                    homeViews: '200',
+                },
+                'findByIdAndDelete'
+            );
+            const res = await request(app)
+                .delete(`/home`)
+                .set('Authorization', `Bearer ${token}`)
+                .send({ home_id: '652beab54298559b57ff172f' });
+
+            expect(res.statusCode).toEqual(200);
+            expect(res.body).toEqual('Home has been deleted');
+        });
     });
 });

--- a/test/home/homePut.test.js
+++ b/test/home/homePut.test.js
@@ -1,6 +1,8 @@
 const mockingoose = require('mockingoose');
+const jwt = require('jsonwebtoken');
 const Homes = require('../../models/Homes');
 const request = require('supertest');
+const User = require('../../models/User');
 const app = require('../../app');
 
 describe('Positive PUT /home', () => {
@@ -42,31 +44,107 @@ describe('Positive PUT /home', () => {
         );
     });
 
-    it('should update a Home and return it', async () => {
-        const res = await request(app).put('/home').send({
-            home_id: '63aca8c7826cd2f2bfda5914',
-            title: 'Nice house Updated',
-            city: 'Dobrich updated',
-            neighborhood: 'Drujba updated',
-            address: 'Blok 42 A 2 8 updated',
-            price: '20000',
-            size: '153',
-            year: '1961',
-            description: 'Really nice house, have 2 rooms, updated',
-            longitude: '32',
-            latitude: '52',
-            owner_id: '632beab54298559b57ff172f',
+    describe('given the request header berer not exist', () => {
+        it('should return a 401', async () => {
+            const { statusCode } = await request(app).put(`/home`);
+            expect(statusCode).toBe(401);
         });
-        expect(res.status).toEqual(200);
-        expect(res.body.title).toEqual('Nice house Updated');
-        expect(res.body.city).toEqual('Dobrich updated');
-        expect(res.body.neighborhood).toEqual('Drujba updated');
-        expect(res.body.address).toEqual('Blok 42 A 2 8 updated');
-        expect(res.body.price).toEqual('20000');
-        expect(res.body.size).toEqual('153');
-        expect(res.body.year).toEqual('1961');
-        expect(res.body.description).toEqual('Really nice house, have 2 rooms, updated');
-        expect(res.body.longitude).toEqual('32');
-        expect(res.body.latitude).toEqual('52');
+    });
+
+    describe('given the token is not valid', () => {
+        it('should return a 403', async () => {
+            const { statusCode } = await request(app)
+                .put(`/home`)
+                .set('Authorization', `Bearer Wrong Token`);
+            expect(statusCode).toBe(403);
+        });
+    });
+
+    describe('given the user dosent have permission', () => {
+        it('should return a 403', async () => {
+            const token = jwt.sign(
+                { auth_id: '63c93c7ea886abcac9deefe8', auth_role: 'user' },
+                process.env.JWT_SECRET,
+                {
+                    expiresIn: '1d',
+                }
+            );
+            const { statusCode } = await request(app)
+                .put(`/home`)
+                .set('Authorization', `Bearer ${token}`);
+            expect(statusCode).toBe(403);
+        });
+    });
+
+    describe('given the home dosent belong to the user', () => {
+        it('should return a 403', async () => {
+            const token = jwt.sign(
+                { auth_id: '63c93c7ea886abcac7deefe8' /*wrong id*/, auth_role: 'seller' },
+                process.env.JWT_SECRET,
+                {
+                    expiresIn: '1d',
+                }
+            );
+            const { statusCode } = await request(app)
+                .put(`/home`)
+                .set('Authorization', `Bearer ${token}`)
+                .send({
+                    home_id: '652beab54298559b57ff172f',
+                    title: 'Nice house',
+                    city: 'Dobrich',
+                    neighborhood: 'Drujba',
+                    address: 'Blok 42 A 2 8',
+                    price: '10000',
+                    size: '150',
+                    year: '1960',
+                    description: 'Really nice house, have 2 rooms',
+                    longitude: '30',
+                    latitude: '50',
+                    owner_id: '632beab54298559b57ff172f',
+                    homeViews: '200',
+                });
+            expect(statusCode).toBe(403);
+        });
+    });
+
+    describe('given the user is logged in and the land belong to him or his the admin', () => {
+        it('should update a Home and return it', async () => {
+            const token = jwt.sign(
+                { auth_id: '632beab54298559b57ff172f', auth_role: 'seller' },
+                process.env.JWT_SECRET,
+                {
+                    expiresIn: '1d',
+                }
+            );
+
+            const res = await request(app)
+                .put('/home')
+                .set('Authorization', `Bearer ${token}`)
+                .send({
+                    home_id: '63aca8c7826cd2f2bfda5914',
+                    title: 'Nice house Updated',
+                    city: 'Dobrich updated',
+                    neighborhood: 'Drujba updated',
+                    address: 'Blok 42 A 2 8 updated',
+                    price: '20000',
+                    size: '153',
+                    year: '1961',
+                    description: 'Really nice house, have 2 rooms, updated',
+                    longitude: '32',
+                    latitude: '52',
+                    owner_id: '632beab54298559b57ff172f',
+                });
+            expect(res.status).toEqual(200);
+            expect(res.body.title).toEqual('Nice house Updated');
+            expect(res.body.city).toEqual('Dobrich updated');
+            expect(res.body.neighborhood).toEqual('Drujba updated');
+            expect(res.body.address).toEqual('Blok 42 A 2 8 updated');
+            expect(res.body.price).toEqual('20000');
+            expect(res.body.size).toEqual('153');
+            expect(res.body.year).toEqual('1961');
+            expect(res.body.description).toEqual('Really nice house, have 2 rooms, updated');
+            expect(res.body.longitude).toEqual('32');
+            expect(res.body.latitude).toEqual('52');
+        });
     });
 });

--- a/test/land/landDelete.test.js
+++ b/test/land/landDelete.test.js
@@ -47,7 +47,6 @@ describe('Positive DELETE /land', () => {
                     expiresIn: '1d',
                 }
             );
-            mockingoose(Land).toReturn(null, 'findOne');
 
             const { statusCode } = await request(app)
                 .delete(`/land`)

--- a/test/land/landDelete.test.js
+++ b/test/land/landDelete.test.js
@@ -1,41 +1,164 @@
 const mockingoose = require('mockingoose');
 const Land = require('../../models/Land');
+const User = require('../../models/User');
 const request = require('supertest');
+const jwt = require('jsonwebtoken');
 const app = require('../../app');
 
 describe('Positive DELETE /land', () => {
-    it('should delete land by id', async () => {
-        mockingoose(Land).toReturn(
-            {
-                _id: '652beab54298559b57ff172f',
-                name: 'Zemedelska zemq',
-                place: 'Spasovo',
-                price: '100000',
-                size: '150',
-                description: 'Zemedelska zemq purva kategoriq. W blizost do ezero.',
-                longitude: "30",
-                latitude: '50',
-                owner: "632beab54298559b57ff172f",
-            },
-            'findOne'
-        );
-        mockingoose(Land).toReturn(
-            {
-                _id: '652beab54298559b57ff172f',
-                name: 'Zemedelska zemq',
-                place: 'Spasovo',
-                price: '100000',
-                size: '150',
-                description: 'Zemedelska zemq purva kategoriq. W blizost do ezero.',
-                longitude: "30",
-                latitude: '50',
-                owner: "632beab54298559b57ff172f",
-            },
-            'findByIdAndDelete'
-        );
-        const res = await request(app).delete(`/land`).send({land_id: "652beab54298559b57ff172f"});
+    describe('given the request header berer not exist', () => {
+        it('should return a 401', async () => {
+            const { statusCode } = await request(app).delete(`/land`);
+            expect(statusCode).toBe(401);
+        });
+    });
 
-        expect(res.statusCode).toEqual(200);
-        expect(res.body).toEqual('Land has been deleted');
+    describe('given the token is not valid', () => {
+        it('should return a 403', async () => {
+            const { statusCode } = await request(app)
+                .delete(`/land`)
+                .set('Authorization', `Bearer Wrong Token`);
+            expect(statusCode).toBe(403);
+        });
+    });
+
+    describe('given the user dosent have permission', () => {
+        it('should return a 403', async () => {
+            const token = jwt.sign(
+                { auth_id: '63c93c7ea886abcac9deefe8', auth_role: 'user' },
+                process.env.JWT_SECRET,
+                {
+                    expiresIn: '1d',
+                }
+            );
+            const { statusCode } = await request(app)
+                .delete(`/land`)
+                .set('Authorization', `Bearer ${token}`);
+            expect(statusCode).toBe(403);
+        });
+    });
+
+    describe('given the land not exist', () => {
+        it('should return a 400', async () => {
+            const token = jwt.sign(
+                { auth_id: '63c93c7ea886abcac9deefe8', auth_role: 'seller' },
+                process.env.JWT_SECRET,
+                {
+                    expiresIn: '1d',
+                }
+            );
+            mockingoose(Land).toReturn(null, 'findOne');
+
+            const { statusCode } = await request(app)
+                .delete(`/land`)
+                .set('Authorization', `Bearer ${token}`)
+                .send({ land_id: '652beab54298449b57ff172f' /*wrong id*/ });
+
+            expect(statusCode).toBe(400);
+        });
+    });
+
+    describe('given the land dosent belong to the user', () => {
+        it('should return a 403', async () => {
+            const token = jwt.sign(
+                { auth_id: '63c93c7ea886abcac7deefe8' /*wrong id*/, auth_role: 'seller' },
+                process.env.JWT_SECRET,
+                {
+                    expiresIn: '1d',
+                }
+            );
+            mockingoose(User).toReturn(
+                {
+                    _id: '63c93c7ea886abcac9deefe8',
+                    first_name: 'test',
+                    last_name: 'test',
+                    email: 'test@gmail.com',
+                    password: '$2b$10$PtuFEjpqdr50hldhr4K36ODgzYKtz6QBO7KxB9OgCgcEP4ihxWuUa',
+                    role: 'seller',
+                    phone_number: '+112557441454',
+                },
+                'findOne'
+            );
+            mockingoose(Land).toReturn(
+                {
+                    _id: '652beab54298559b57ff172f',
+                    name: 'Zemedelska zemq',
+                    place: 'Spasovo',
+                    price: '100000',
+                    size: '150',
+                    description: 'Zemedelska zemq purva kategoriq. W blizost do ezero.',
+                    longitude: '30',
+                    latitude: '50',
+                    owner: '63c93c7ea886abcac9deefe8',
+                },
+                'findOne'
+            );
+            const { statusCode } = await request(app)
+                .delete(`/land`)
+                .set('Authorization', `Bearer ${token}`)
+                .send({ land_id: '652beab54298559b57ff172f' });
+            expect(statusCode).toBe(403);
+        });
+    });
+
+    describe('given the user is logged in', () => {
+        it('should delete land by id', async () => {
+            const token = jwt.sign(
+                { auth_id: '63c93c7ea886abcac9deefe8', auth_role: 'seller' },
+                process.env.JWT_SECRET,
+                {
+                    expiresIn: '1d',
+                }
+            );
+
+            mockingoose(User).toReturn(
+                {
+                    _id: '63c93c7ea886abcac9deefe8',
+                    first_name: 'test',
+                    last_name: 'test',
+                    email: 'test@gmail.com',
+                    password: '$2b$10$PtuFEjpqdr50hldhr4K36ODgzYKtz6QBO7KxB9OgCgcEP4ihxWuUa',
+                    role: 'seller',
+                    phone_number: '+112557441454',
+                },
+                'findOne'
+            );
+            mockingoose(Land).toReturn(
+                {
+                    _id: '652beab54298559b57ff172f',
+                    name: 'Zemedelska zemq',
+                    place: 'Spasovo',
+                    price: '100000',
+                    size: '150',
+                    description: 'Zemedelska zemq purva kategoriq. W blizost do ezero.',
+                    longitude: '30',
+                    latitude: '50',
+                    owner: '63c93c7ea886abcac9deefe8',
+                },
+                'findOne'
+            );
+            mockingoose(Land).toReturn(
+                {
+                    _id: '652beab54298559b57ff172f',
+                    name: 'Zemedelska zemq',
+                    place: 'Spasovo',
+                    price: '100000',
+                    size: '150',
+                    description: 'Zemedelska zemq purva kategoriq. W blizost do ezero.',
+                    longitude: '30',
+                    latitude: '50',
+                    owner: '63c93c7ea886abcac9deefe8',
+                },
+                'findByIdAndDelete'
+            );
+
+            const res = await request(app)
+                .delete(`/land`)
+                .set('Authorization', `Bearer ${token}`)
+                .send({ land_id: '652beab54298559b57ff172f' });
+
+            expect(res.statusCode).toBe(200);
+            expect(res.body).toEqual('Land has been deleted');
+        });
     });
 });

--- a/test/land/landPost.test.js
+++ b/test/land/landPost.test.js
@@ -1,4 +1,5 @@
 const mockingoose = require('mockingoose');
+const jwt = require('jsonwebtoken');
 const Land = require('../../models/Land');
 const request = require('supertest');
 const app = require('../../app');
@@ -14,32 +15,78 @@ describe('Positive POST /land', () => {
                 price: '100000',
                 size: '150',
                 description: 'Zemedelska zemq purva kategoriq. W blizost do ezero.',
-                longitude: "30",
+                longitude: '30',
                 latitude: '50',
-                owner: "632beab54298559b57ff172f",
+                owner: '632beab54298559b57ff172f',
             },
             'save'
         );
     });
 
-    it('should create a new Land and return it', async () => {
-        const res = await request(app).post('/land').send({
-            name: 'Zemedelska zemq',
-            place: 'Spasovo',
-            price: '100000',
-            size: '150',
-            description: 'Zemedelska zemq purva kategoriq. W blizost do ezero.',
-            longitude: "30",
-            latitude: '50',
-            owner: "632beab54298559b57ff172f",
+    describe('given the request header berer not exist', () => {
+        it('should return a 401', async () => {
+            const { statusCode } = await request(app).post(`/land`);
+            expect(statusCode).toBe(401);
         });
-        expect(res.status).toEqual(201);
-        expect(res.body.name).toEqual('Zemedelska zemq');
-        expect(res.body.place).toEqual('Spasovo');
-        expect(res.body.price).toEqual(100000);
-        expect(res.body.size).toEqual('150');
-        expect(res.body.description).toEqual('Zemedelska zemq purva kategoriq. W blizost do ezero.');
-        expect(res.body.longitude).toEqual('30');
-        expect(res.body.latitude).toEqual('50');
+    });
+
+    describe('given the token is not valid', () => {
+        it('should return a 403', async () => {
+            const { statusCode } = await request(app)
+                .post(`/land`)
+                .set('Authorization', `Bearer Wrong Token`);
+            expect(statusCode).toBe(403);
+        });
+    });
+
+    describe('given the user dosent have permission', () => {
+        it('should return a 403', async () => {
+            const token = jwt.sign(
+                { auth_id: '63c93c7ea886abcac9deefe8', auth_role: 'user' },
+                process.env.JWT_SECRET,
+                {
+                    expiresIn: '1d',
+                }
+            );
+            const { statusCode } = await request(app)
+                .post(`/land`)
+                .set('Authorization', `Bearer ${token}`);
+            expect(statusCode).toBe(403);
+        });
+    });
+
+    describe('given the user is logged in', () => {
+        it('should create a new Land and return it', async () => {
+            const token = jwt.sign(
+                { auth_id: '63c93c7ea886abcac9deefe8', auth_role: 'seller' },
+                process.env.JWT_SECRET,
+                {
+                    expiresIn: '1d',
+                }
+            );
+            const res = await request(app)
+                .post('/land')
+                .set('Authorization', `Bearer ${token}`)
+                .send({
+                    name: 'Zemedelska zemq',
+                    place: 'Spasovo',
+                    price: '100000',
+                    size: '150',
+                    description: 'Zemedelska zemq purva kategoriq. W blizost do ezero.',
+                    longitude: '30',
+                    latitude: '50',
+                    owner: '632beab54298559b57ff172f',
+                });
+            expect(res.status).toEqual(201);
+            expect(res.body.name).toEqual('Zemedelska zemq');
+            expect(res.body.place).toEqual('Spasovo');
+            expect(res.body.price).toEqual(100000);
+            expect(res.body.size).toEqual('150');
+            expect(res.body.description).toEqual(
+                'Zemedelska zemq purva kategoriq. W blizost do ezero.'
+            );
+            expect(res.body.longitude).toEqual('30');
+            expect(res.body.latitude).toEqual('50');
+        });
     });
 });

--- a/test/land/landPut.test.js
+++ b/test/land/landPut.test.js
@@ -1,4 +1,5 @@
 const mockingoose = require('mockingoose');
+const jwt = require('jsonwebtoken');
 const Land = require('../../models/Land');
 const request = require('supertest');
 const app = require('../../app');
@@ -14,9 +15,9 @@ describe('Positive PUT /land', () => {
                 price: '100000',
                 size: '150',
                 description: 'Zemedelska zemq purva kategoriq. W blizost do ezero.',
-                longitude: "30",
+                longitude: '30',
                 latitude: '50',
-                owner: "632beab54298559b57ff172f",
+                owner: '632beab54298559b57ff172f',
             },
             'findOne'
         );
@@ -28,33 +29,106 @@ describe('Positive PUT /land', () => {
                 price: '100000',
                 size: '150',
                 description: 'Zemedelska zemq purva kategoriq. W blizost do ezero.',
-                longitude: "30",
+                longitude: '30',
                 latitude: '50',
-                owner: "632beab54298559b57ff172f",
+                owner: '632beab54298559b57ff172f',
             },
             'save'
         );
     });
 
-    it('should update a Land and return it', async () => {
-        const res = await request(app).put('/land').send({
-            land_id: "652beab54298559b57ff172f",
-            name: 'Zemedelska zemq updated',
-            place: 'Rogozina',
-            price: '200000',
-            size: '250',
-            description: 'Zemedelska zemq vtora kategoriq. W blizost do seloto.',
-            longitude: "35",
-            latitude: '55',
-            owner: "632beab54298559b57ff172f",
+    describe('given the request header berer not exist', () => {
+        it('should return a 401', async () => {
+            const { statusCode } = await request(app).put(`/land`);
+            expect(statusCode).toBe(401);
         });
-        expect(res.status).toEqual(200);
-        expect(res.body.name).toEqual('Zemedelska zemq updated');
-        expect(res.body.place).toEqual('Rogozina');
-        expect(res.body.price).toEqual(200000);
-        expect(res.body.size).toEqual('250');
-        expect(res.body.description).toEqual('Zemedelska zemq vtora kategoriq. W blizost do seloto.');
-        expect(res.body.longitude).toEqual('35');
-        expect(res.body.latitude).toEqual('55');
+    });
+
+    describe('given the token is not valid', () => {
+        it('should return a 403', async () => {
+            const { statusCode } = await request(app)
+                .put(`/land`)
+                .set('Authorization', `Bearer Wrong Token`);
+            expect(statusCode).toBe(403);
+        });
+    });
+
+    describe('given the user dosent have permission', () => {
+        it('should return a 403', async () => {
+            const token = jwt.sign(
+                { auth_id: '63c93c7ea886abcac9deefe8', auth_role: 'user' },
+                process.env.JWT_SECRET,
+                {
+                    expiresIn: '1d',
+                }
+            );
+            const { statusCode } = await request(app)
+                .put(`/land`)
+                .set('Authorization', `Bearer ${token}`);
+            expect(statusCode).toBe(403);
+        });
+    });
+
+    describe('given the land dosent belong to the user', () => {
+        it('should return a 403', async () => {
+            const token = jwt.sign(
+                { auth_id: '63c93c7ea886abcac7deefe8' /*wrong id*/, auth_role: 'seller' },
+                process.env.JWT_SECRET,
+                {
+                    expiresIn: '1d',
+                }
+            );
+            const { statusCode } = await request(app)
+                .put(`/land`)
+                .set('Authorization', `Bearer ${token}`)
+                .send({
+                    land_id: '652beab54298559b57ff172f',
+                    name: 'Zemedelska zemq updated',
+                    place: 'Rogozina',
+                    price: '200000',
+                    size: '250',
+                    description: 'Zemedelska zemq vtora kategoriq. W blizost do seloto.',
+                    longitude: '35',
+                    latitude: '55',
+                    owner: '632beab54298559b57ff172f',
+                });
+            expect(statusCode).toBe(403);
+        });
+    });
+
+    describe('given the user is logged in and the land belong to him or his the admin', () => {
+        it('should update a Land and return it', async () => {
+            const token = jwt.sign(
+                { auth_id: '632beab54298559b57ff172f', auth_role: 'seller' },
+                process.env.JWT_SECRET,
+                {
+                    expiresIn: '1d',
+                }
+            );
+            const res = await request(app)
+                .put('/land')
+                .set('Authorization', `Bearer ${token}`)
+                .send({
+                    land_id: '652beab54298559b57ff172f',
+                    name: 'Zemedelska zemq updated',
+                    place: 'Rogozina',
+                    price: '200000',
+                    size: '250',
+                    description: 'Zemedelska zemq vtora kategoriq. W blizost do seloto.',
+                    longitude: '35',
+                    latitude: '55',
+                    owner: '632beab54298559b57ff172f',
+                });
+            expect(res.status).toEqual(200);
+            expect(res.body.name).toEqual('Zemedelska zemq updated');
+            expect(res.body.place).toEqual('Rogozina');
+            expect(res.body.price).toEqual(200000);
+            expect(res.body.size).toEqual('250');
+            expect(res.body.description).toEqual(
+                'Zemedelska zemq vtora kategoriq. W blizost do seloto.'
+            );
+            expect(res.body.longitude).toEqual('35');
+            expect(res.body.latitude).toEqual('55');
+        });
     });
 });


### PR DESCRIPTION
I added tests for land and home CRUD operations with authorization and authentication.

I want to do another test for the login and logout but it seems there is a bug in Supertest, when I try to test this route "/auth/login" it always returns a 404 error.